### PR TITLE
Refactor color handling into shared utilities

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -1,0 +1,60 @@
+import math
+from typing import Sequence, Callable, List
+from PIL import Image
+
+
+def projection_on_circle(
+    point_x: float, point_y: float, circle_x: float, circle_y: float, radius: float
+) -> tuple[float, float]:
+    """Project a point onto the circumference of a circle."""
+    angle = math.atan2(point_y - circle_y, point_x - circle_x)
+    projection_x = circle_x + radius * math.cos(angle)
+    projection_y = circle_y + radius * math.sin(angle)
+    return projection_x, projection_y
+
+
+def get_target_color(
+    image: Image.Image, target_x: int, target_y: int, default_rgb: Sequence[int]
+) -> List[int]:
+    """Return the RGB color of ``image`` at the given coordinates."""
+    try:
+        r, g, b = image.getpixel((target_x, target_y))[:3]
+        return [r, g, b]
+    except AttributeError:
+        return list(default_rgb)
+
+
+def update_colors(
+    image: Image.Image,
+    target_x: int,
+    target_y: int,
+    brightness: int,
+    default_rgb: Sequence[int],
+    slider: any,
+    label: any,
+    command: Callable[[str], None] | None = None,
+    get_callback: Callable[[], str] | None = None,
+) -> tuple[list[int], str]:
+    """Update color widgets and return the RGB list and hex color."""
+    rgb_color = get_target_color(image, target_x, target_y, default_rgb)
+    r = int(rgb_color[0] * (brightness / 255))
+    g = int(rgb_color[1] * (brightness / 255))
+    b = int(rgb_color[2] * (brightness / 255))
+    rgb_color = [r, g, b]
+    hex_color = "#{:02x}{:02x}{:02x}".format(*rgb_color)
+
+    slider.configure(progress_color=hex_color)
+    label.configure(fg_color=hex_color)
+    label.configure(text=str(hex_color))
+
+    if brightness < 70:
+        label.configure(text_color="white")
+    else:
+        label.configure(text_color="black")
+    if str(label._fg_color) == "black":
+        label.configure(text_color="white")
+
+    if command and get_callback:
+        command(get_callback())
+
+    return rgb_color, hex_color

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -8,6 +8,8 @@ import os
 import math
 from typing import Any, Callable
 
+from .color_utils import projection_on_circle, update_colors as utils_update_colors
+
 PATH = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -175,7 +177,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         if d_from_center < self.image_dimension / 2:
             self.target_x, self.target_y = x, y
         else:
-            self.target_x, self.target_y = self.projection_on_circle(
+            self.target_x, self.target_y = projection_on_circle(
                 x,
                 y,
                 self.image_dimension / 2,
@@ -185,69 +187,23 @@ class CTkColorPicker(customtkinter.CTkFrame):
 
         self.canvas.create_image(self.target_x, self.target_y, image=self.target)
 
-        self.get_target_color()
         self.update_colors()
-
-    def get_target_color(self) -> None:
-        """Retrieve the RGB color at the target position on the wheel."""
-
-        try:
-            self.rgb_color = self.img1.getpixel((self.target_x, self.target_y))
-
-            r = self.rgb_color[0]
-            g = self.rgb_color[1]
-            b = self.rgb_color[2]
-            self.rgb_color = [r, g, b]
-
-        except AttributeError:
-            self.rgb_color = self.default_rgb
 
     def update_colors(self) -> None:
         """Update widget colors and invoke the callback if provided."""
 
-        brightness = self.brightness_slider_value.get()
+        self.rgb_color, self.default_hex_color = utils_update_colors(
+            self.img1,
+            getattr(self, "target_x", 0),
+            getattr(self, "target_y", 0),
+            self.brightness_slider_value.get(),
+            self.default_rgb,
+            self.slider,
+            self.label,
+            command=self.command,
+            get_callback=self.get,
+        )
 
-        self.get_target_color()
-
-        r = int(self.rgb_color[0] * (brightness / 255))
-        g = int(self.rgb_color[1] * (brightness / 255))
-        b = int(self.rgb_color[2] * (brightness / 255))
-
-        self.rgb_color = [r, g, b]
-
-        self.default_hex_color = "#{:02x}{:02x}{:02x}".format(*self.rgb_color)
-
-        self.slider.configure(progress_color=self.default_hex_color)
-        self.label.configure(fg_color=self.default_hex_color)
-
-        self.label.configure(text=str(self.default_hex_color))
-
-        if self.brightness_slider_value.get() < 70:
-            self.label.configure(text_color="white")
-        else:
-            self.label.configure(text_color="black")
-
-        if str(self.label._fg_color) == "black":
-            self.label.configure(text_color="white")
-
-        if self.command:
-            self.command(self.get())
-
-    def projection_on_circle(
-        self,
-        point_x: float,
-        point_y: float,
-        circle_x: float,
-        circle_y: float,
-        radius: float,
-    ) -> tuple[float, float]:
-        """Project a point onto the circumference of a circle."""
-
-        angle = math.atan2(point_y - circle_y, point_x - circle_x)
-        projection_x = circle_x + radius * math.cos(angle)
-        projection_y = circle_y + radius * math.sin(angle)
-
-        return projection_x, projection_y
 
     def set_initial_color(self, initial_color: str | None) -> None:
         """Position the target to match ``initial_color`` if possible."""


### PR DESCRIPTION
## Summary
- add `color_utils` module with projection and color calculation helpers
- refactor AskColor and CTkColorPicker to use shared utilities and remove duplicate methods

## Testing
- `python -m py_compile CTkColorPicker/color_utils.py CTkColorPicker/ctk_color_picker.py CTkColorPicker/ctk_color_picker_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_68964171e7ec8321820ce9fc7dc279ad