### PR TITLE
Use context managers for image loading

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -132,15 +132,18 @@ class AskColor(customtkinter.CTkToplevel):
         self.canvas.pack(pady=20)
         self.canvas.bind("<B1-Motion>", self.on_mouse_drag)
 
-        self.img1 = Image.open(os.path.join(PATH, "color_wheel.png")).resize(
-            (self.image_dimension, self.image_dimension), Image.Resampling.LANCZOS
-        )
-        self.img2 = Image.open(os.path.join(PATH, "target.png")).resize(
-            (self.target_dimension, self.target_dimension), Image.Resampling.LANCZOS
-        )
-
-        self.wheel = ImageTk.PhotoImage(self.img1)
-        self.target = ImageTk.PhotoImage(self.img2)
+        with Image.open(os.path.join(PATH, "color_wheel.png")) as img:
+            self.img1 = img.resize(
+                (self.image_dimension, self.image_dimension),
+                Image.Resampling.LANCZOS,
+            )
+            self.wheel = ImageTk.PhotoImage(self.img1)
+        with Image.open(os.path.join(PATH, "target.png")) as img:
+            self.img2 = img.resize(
+                (self.target_dimension, self.target_dimension),
+                Image.Resampling.LANCZOS,
+            )
+            self.target = ImageTk.PhotoImage(self.img2)
 
         self.canvas.create_image(
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -88,15 +88,18 @@ class CTkColorPicker(customtkinter.CTkFrame):
         )
         self.canvas.bind("<B1-Motion>", self.on_mouse_drag)
 
-        self.img1 = Image.open(os.path.join(PATH, "color_wheel.png")).resize(
-            (self.image_dimension, self.image_dimension), Image.Resampling.LANCZOS
-        )
-        self.img2 = Image.open(os.path.join(PATH, "target.png")).resize(
-            (self.target_dimension, self.target_dimension), Image.Resampling.LANCZOS
-        )
-
-        self.wheel = ImageTk.PhotoImage(self.img1)
-        self.target = ImageTk.PhotoImage(self.img2)
+        with Image.open(os.path.join(PATH, "color_wheel.png")) as img:
+            self.img1 = img.resize(
+                (self.image_dimension, self.image_dimension),
+                Image.Resampling.LANCZOS,
+            )
+            self.wheel = ImageTk.PhotoImage(self.img1)
+        with Image.open(os.path.join(PATH, "target.png")) as img:
+            self.img2 = img.resize(
+                (self.target_dimension, self.target_dimension),
+                Image.Resampling.LANCZOS,
+            )
+            self.target = ImageTk.PhotoImage(self.img2)
 
         self.canvas.create_image(
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel


### PR DESCRIPTION
## Summary
- wrap color wheel and target image loading in `with Image.open(...)` blocks
- create `ImageTk.PhotoImage` instances inside the context managers to release file handles sooner

## Testing
- `python -m py_compile CTkColorPicker/*.py`
- `pip install customtkinter` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python - <<'PY'` *(fails: No module named 'customtkinter')*
- `python - <<'PY'` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6896440155148321a6a47eef6a25b349