### PR TITLE
Allow running demo example without installation

### DIFF
--- a/examples/demo_color_picker.py
+++ b/examples/demo_color_picker.py
@@ -1,3 +1,6 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import customtkinter as ctk
 from CTkColorPicker import AskColor, CTkColorPicker
 


### PR DESCRIPTION
## Summary
- add project root to `sys.path` in demo script so it can import `CTkColorPicker`

## Testing
- `python examples/demo_color_picker.py` *(fails: no display name and no $DISPLAY environment variable)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896515f55c48321bebb73d3d3fe44af