### PR TITLE
Add hex entry with normalization to AskColor dialog

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -1,6 +1,32 @@
 import math
 from typing import Sequence, Callable, List
 from PIL import Image
+import string
+
+
+def normalize_hex_color(value: str) -> str:
+    """Return a normalized ``#rrggbb`` color string or raise ``ValueError``."""
+
+    if value is None:
+        raise ValueError("No color provided")
+    value = value.strip().lower()
+    if not value:
+        raise ValueError("No color provided")
+    if not value.startswith("#"):
+        value = "#" + value
+    hex_part = value[1:]
+    if len(hex_part) == 3:
+        if all(c in string.hexdigits for c in hex_part):
+            value = "#" + "".join(c * 2 for c in hex_part)
+        else:
+            raise ValueError("Invalid hex digits")
+    elif len(hex_part) == 6:
+        if not all(c in string.hexdigits for c in hex_part):
+            raise ValueError("Invalid hex digits")
+        value = "#" + hex_part
+    else:
+        raise ValueError("Invalid length for hex color")
+    return value
 
 
 def projection_on_circle(
@@ -44,8 +70,14 @@ def update_colors(
     hex_color = "#{:02x}{:02x}{:02x}".format(*rgb_color)
 
     slider.configure(progress_color=hex_color)
-    label.configure(fg_color=hex_color)
-    label.configure(text=str(hex_color))
+
+    if hasattr(label, "delete") and hasattr(label, "insert"):
+        label.configure(fg_color=hex_color)
+        label.delete(0, "end")
+        label.insert(0, hex_color)
+    else:
+        label.configure(fg_color=hex_color)
+        label.configure(text=str(hex_color))
 
     if brightness < 70:
         label.configure(text_color="white")

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import pytest
 
 # Stub PIL.Image to avoid Pillow dependency
 PIL_module = types.ModuleType('PIL')
@@ -15,7 +16,7 @@ sys.modules['PIL.Image'] = Image_module
 # Add package directory to path without importing package __init__
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'CTkColorPicker'))
 
-from color_utils import update_colors
+from color_utils import update_colors, normalize_hex_color
 
 
 class DummyWidget:
@@ -66,3 +67,20 @@ def test_callback_invoked():
 
     update_colors(img, 0, 0, 255, [0, 0, 0], slider, label, command=callback, get_callback=getter)
     assert received == ['#ff0000']
+
+
+def test_normalize_hex_color_shorthand():
+    assert normalize_hex_color('#fff') == '#ffffff'
+    assert normalize_hex_color('abc') == '#aabbcc'
+
+
+def test_normalize_hex_color_full():
+    assert normalize_hex_color('#123456') == '#123456'
+    assert normalize_hex_color('123456') == '#123456'
+
+
+def test_normalize_hex_color_invalid():
+    with pytest.raises(ValueError):
+        normalize_hex_color('#ff')
+    with pytest.raises(ValueError):
+        normalize_hex_color('ggg')


### PR DESCRIPTION
## Summary
- Replace color preview label with editable CTkEntry and bind validation events
- Add `normalize_hex_color` helper and `apply_hex_input` to validate and apply entry values
- Update utilities and tests for entry support and shorthand hex normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965bdd455c8321a0652abc3a20a439