### PR TITLE
Replace label with entry and support hex input

### DIFF
--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -8,7 +8,11 @@ import os
 import math
 from typing import Any, Callable
 
-from .color_utils import projection_on_circle, update_colors as utils_update_colors
+from .color_utils import (
+    projection_on_circle,
+    update_colors as utils_update_colors,
+    normalize_hex_color,
+)
 
 PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -126,31 +130,41 @@ class CTkColorPicker(customtkinter.CTkFrame):
             **slider_kwargs,
         )
 
-        self.label = customtkinter.CTkLabel(
+        self.entry = customtkinter.CTkEntry(
             master=self,
             text_color="#000000",
             width=10,
             fg_color=self.default_hex_color,
             corner_radius=self.corner_radius,
-            text=self.default_hex_color,
-            wraplength=1,
+            justify="center",
         )
+        self.entry.insert(0, self.default_hex_color)
+        self.entry.bind("<FocusOut>", self.apply_hex_input)
+        self.entry.bind("<Return>", self.apply_hex_input)
+
         if orientation == "vertical":
+            try:
+                self.entry.configure(wraplength=1)
+            except tkinter.TclError:
+                pass
             self.canvas.pack(pady=20, side="left", padx=(10, 0))
             self.slider.pack(
                 fill="y", pady=15, side="right", padx=(0, 10 - self.slider_border)
             )
-            self.label.pack(expand=True, fill="both", padx=10, pady=15)
+            self.entry.pack(expand=True, fill="both", padx=10, pady=15)
         else:
-            self.label.configure(wraplength=100)
+            try:
+                self.entry.configure(wraplength=100)
+            except tkinter.TclError:
+                pass
             self.canvas.pack(pady=15, padx=15)
             self.slider.pack(fill="x", pady=(0, 10 - self.slider_border), padx=15)
-            self.label.pack(expand=True, fill="both", padx=15, pady=(0, 15))
+            self.entry.pack(expand=True, fill="both", padx=15, pady=(0, 15))
 
     def get(self) -> str:
         """Return the currently selected color as a hexadecimal string."""
 
-        self._color = self.label._fg_color
+        self._color = self.entry._fg_color
         return self._color
 
     def destroy(self) -> None:
@@ -202,10 +216,43 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.brightness_slider_value.get(),
             self.default_rgb,
             self.slider,
-            self.label,
+            self.entry,
             command=self.command,
             get_callback=self.get,
         )
+
+    def apply_hex_input(self, event: tkinter.Event | None = None) -> None:
+        """Validate and apply the hex color entered by the user."""
+
+        value = self.entry.get().strip()
+        try:
+            normalized = normalize_hex_color(value)
+        except ValueError:
+            self.entry.delete(0, "end")
+            self.entry.insert(0, self.default_hex_color)
+            self.entry.configure(fg_color=self.default_hex_color)
+            self.slider.configure(progress_color=self.default_hex_color)
+            self.brightness_slider_value.set(255)
+            self.entry.focus()
+            return
+
+        r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
+        self.default_hex_color = normalized
+        self.rgb_color = [r, g, b]
+        self.entry.delete(0, "end")
+        self.entry.insert(0, normalized)
+        self.entry.configure(fg_color=normalized)
+        self.slider.configure(progress_color=normalized)
+        self.brightness_slider_value.set(255)
+
+        brightness = 0.299 * r + 0.587 * g + 0.114 * b
+        if brightness < 70 or normalized == "#000000":
+            self.entry.configure(text_color="white")
+        else:
+            self.entry.configure(text_color="black")
+
+        if self.command:
+            self.command(self.get())
 
 
     def set_initial_color(self, initial_color: str | None) -> None:


### PR DESCRIPTION
## Summary
- Replace CTkLabel with editable CTkEntry for color display.
- Add apply_hex_input to validate user hex input and update slider + callbacks.
- Bind entry events to apply_hex_input and propagate color changes.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896621b08988321a1ee1077369fd046