### PR TITLE
feat: support entries in update_colors

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -57,7 +57,7 @@ def update_colors(
     brightness: int,
     default_rgb: Sequence[int],
     slider: any,
-    label: any,
+    widget: any,
     command: Callable[[str], None] | None = None,
     get_callback: Callable[[], str] | None = None,
 ) -> tuple[list[int], str]:
@@ -71,20 +71,22 @@ def update_colors(
 
     slider.configure(progress_color=hex_color)
 
-    if hasattr(label, "delete") and hasattr(label, "insert"):
-        label.configure(fg_color=hex_color)
-        label.delete(0, "end")
-        label.insert(0, hex_color)
+    if hasattr(widget, "delete"):
+        widget.configure(fg_color=hex_color)
+        widget.delete(0, "end")
+        widget.insert(0, hex_color)
     else:
-        label.configure(fg_color=hex_color)
-        label.configure(text=str(hex_color))
+        try:
+            widget.configure(fg_color=hex_color, text=str(hex_color))
+        except Exception:
+            widget.configure(fg_color=hex_color)
 
     if brightness < 70:
-        label.configure(text_color="white")
+        widget.configure(text_color="white")
     else:
-        label.configure(text_color="black")
-    if str(label._fg_color) == "black":
-        label.configure(text_color="white")
+        widget.configure(text_color="black")
+    if str(widget._fg_color) == "black":
+        widget.configure(text_color="white")
 
     if command and get_callback:
         command(get_callback())

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -30,6 +30,18 @@ class DummyWidget:
             self._fg_color = kwargs['fg_color']
 
 
+class DummyEntry(DummyWidget):
+    def __init__(self):
+        super().__init__()
+        self.text = ""
+
+    def delete(self, start, end):
+        self.text = ""
+
+    def insert(self, index, value):
+        self.text = value
+
+
 class DummyImage:
     def __init__(self, color):
         self.color = color
@@ -67,6 +79,15 @@ def test_callback_invoked():
 
     update_colors(img, 0, 0, 255, [0, 0, 0], slider, label, command=callback, get_callback=getter)
     assert received == ['#ff0000']
+
+
+def test_update_colors_entry_widget():
+    img = DummyImage((0, 255, 0))
+    slider, entry = DummyWidget(), DummyEntry()
+    update_colors(img, 0, 0, 255, [0, 0, 0], slider, entry)
+    assert entry.text == '#00ff00'
+    assert entry._fg_color == '#00ff00'
+    assert entry.config['text_color'] == 'black'
 
 
 def test_normalize_hex_color_shorthand():


### PR DESCRIPTION
## Summary
- broaden `update_colors` to handle both CTkEntry and label-like widgets
- track text updates on entry widgets and maintain color settings
- add unit test coverage for entry widget behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68966377ae948321b6d882a231a00030