### PR TITLE
Centralize hex color validation

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -4,29 +4,21 @@ from PIL import Image
 import string
 
 
-def normalize_hex_color(value: str) -> str:
-    """Return a normalized ``#rrggbb`` color string or raise ``ValueError``."""
+def normalize_hex(value: str | None) -> str | None:
+    """Return a normalized ``#rrggbb`` color string or ``None`` if invalid."""
 
     if value is None:
-        raise ValueError("No color provided")
+        return None
     value = value.strip().lower()
     if not value:
-        raise ValueError("No color provided")
-    if not value.startswith("#"):
-        value = "#" + value
-    hex_part = value[1:]
-    if len(hex_part) == 3:
-        if all(c in string.hexdigits for c in hex_part):
-            value = "#" + "".join(c * 2 for c in hex_part)
-        else:
-            raise ValueError("Invalid hex digits")
-    elif len(hex_part) == 6:
-        if not all(c in string.hexdigits for c in hex_part):
-            raise ValueError("Invalid hex digits")
-        value = "#" + hex_part
-    else:
-        raise ValueError("Invalid length for hex color")
-    return value
+        return None
+    if value.startswith("#"):
+        value = value[1:]
+    if len(value) == 3 and all(c in string.hexdigits for c in value):
+        return "#" + "".join(c * 2 for c in value)
+    if len(value) == 6 and all(c in string.hexdigits for c in value):
+        return "#" + value
+    return None
 
 
 def projection_on_circle(

--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -12,7 +12,7 @@ from typing import Any
 from .color_utils import (
     projection_on_circle,
     update_colors as utils_update_colors,
-    normalize_hex_color,
+    normalize_hex,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -303,9 +303,8 @@ class AskColor(customtkinter.CTkToplevel):
         """Validate and apply the hex color entered by the user."""
 
         value = self.entry.get().strip()
-        try:
-            normalized = normalize_hex_color(value)
-        except ValueError:
+        normalized = normalize_hex(value)
+        if normalized is None:
             self.entry.delete(0, "end")
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 from .color_utils import (
     projection_on_circle,
     update_colors as utils_update_colors,
-    normalize_hex_color,
+    normalize_hex,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -225,9 +225,8 @@ class CTkColorPicker(customtkinter.CTkFrame):
         """Validate and apply the hex color entered by the user."""
 
         value = self.entry.get().strip()
-        try:
-            normalized = normalize_hex_color(value)
-        except ValueError:
+        normalized = normalize_hex(value)
+        if normalized is None:
             self.entry.delete(0, "end")
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -16,7 +16,7 @@ sys.modules['PIL.Image'] = Image_module
 # Add package directory to path without importing package __init__
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'CTkColorPicker'))
 
-from color_utils import update_colors, normalize_hex_color
+from color_utils import update_colors, normalize_hex
 
 
 class DummyWidget:
@@ -90,18 +90,15 @@ def test_update_colors_entry_widget():
     assert entry.config['text_color'] == 'black'
 
 
-def test_normalize_hex_color_shorthand():
-    assert normalize_hex_color('#fff') == '#ffffff'
-    assert normalize_hex_color('abc') == '#aabbcc'
+def test_normalize_hex_valid():
+    assert normalize_hex('#fff') == '#ffffff'
+    assert normalize_hex('abc') == '#aabbcc'
+    assert normalize_hex('#123456') == '#123456'
+    assert normalize_hex('123456') == '#123456'
 
 
-def test_normalize_hex_color_full():
-    assert normalize_hex_color('#123456') == '#123456'
-    assert normalize_hex_color('123456') == '#123456'
-
-
-def test_normalize_hex_color_invalid():
-    with pytest.raises(ValueError):
-        normalize_hex_color('#ff')
-    with pytest.raises(ValueError):
-        normalize_hex_color('ggg')
+def test_normalize_hex_invalid():
+    assert normalize_hex('#ff') is None
+    assert normalize_hex('ggg') is None
+    assert normalize_hex('') is None
+    assert normalize_hex(None) is None


### PR DESCRIPTION
## Summary
- add `normalize_hex` to standardize `#rrggbb` strings
- use `normalize_hex` in apply_hex_input methods for consistent validation
- test hex normalization and invalid input handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689664da8c18832197f13dcf3ce46054