### PR TITLE
Fix slider bug when initial color is white

### DIFF
--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -284,3 +284,5 @@ class CTkColorPicker(customtkinter.CTkFrame):
         self.canvas.create_image(
             self.image_dimension / 2, self.image_dimension / 2, image=self.target
         )
+        self.target_x = self.image_dimension // 2
+        self.target_y = self.image_dimension // 2


### PR DESCRIPTION
## Summary
- ensure color picker assigns center coordinates when initial color is not found in wheel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896825ec6d88321adedc7d8c83cfa4d