### PR TITLE
Enable color selection by clicking on wheel

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -134,6 +134,7 @@ class AskColor(customtkinter.CTkToplevel):
             bg=self.fg_color,
         )
         self.canvas.pack(pady=20)
+        self.canvas.bind("<Button-1>", self.on_mouse_drag)
         self.canvas.bind("<B1-Motion>", self.on_mouse_drag)
 
         with Image.open(os.path.join(PATH, "color_wheel.png")) as img:
@@ -251,7 +252,7 @@ class AskColor(customtkinter.CTkToplevel):
         del self.target
 
     def on_mouse_drag(self, event: tkinter.Event) -> None:
-        """Update the target location while the user drags the mouse.
+        """Move the target when the user clicks or drags the mouse.
 
         Parameters
         ----------

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -90,6 +90,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             highlightthickness=0,
             bg=self.fg_color,
         )
+        self.canvas.bind("<Button-1>", self.on_mouse_drag)
         self.canvas.bind("<B1-Motion>", self.on_mouse_drag)
 
         with Image.open(os.path.join(PATH, "color_wheel.png")) as img:
@@ -177,7 +178,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         del self.target
 
     def on_mouse_drag(self, event: tkinter.Event) -> None:
-        """Update the target while the user drags the mouse over the wheel."""
+        """Move the target when the user clicks or drags on the wheel."""
 
         x = event.x
         y = event.y


### PR DESCRIPTION
## Summary
- Allow clicking on the color wheel to move the reticle and update the selected color
- Clarify docstrings to mention click support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689685f0d3dc83219099c13b28621e65