### PR TITLE
Handle ValueError in entry wraplength configuration

### DIFF
--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -146,7 +146,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         if orientation == "vertical":
             try:
                 self.entry.configure(wraplength=1)
-            except tkinter.TclError:
+            except (tkinter.TclError, ValueError):
                 pass
             self.canvas.pack(pady=20, side="left", padx=(10, 0))
             self.slider.pack(
@@ -156,7 +156,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         else:
             try:
                 self.entry.configure(wraplength=100)
-            except tkinter.TclError:
+            except (tkinter.TclError, ValueError):
                 pass
             self.canvas.pack(pady=15, padx=15)
             self.slider.pack(fill="x", pady=(0, 10 - self.slider_border), padx=15)


### PR DESCRIPTION
## Summary
- avoid crashes when entry wraplength cannot be configured by also catching `ValueError`

## Testing
- `pytest -q`
- `timeout 5 python examples/demo_color_picker.py` *(fails: TclError: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6897b146518c8321be10c15d2cd98f9d