### PR TITLE
Sync programmatic color state

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -296,7 +296,7 @@ class AskColor(customtkinter.CTkToplevel):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             self.brightness_slider_value.get(),
-            self.default_rgb,
+            self.default_rgb[:],
             self.slider,
             self.entry,
         )
@@ -331,8 +331,9 @@ class AskColor(customtkinter.CTkToplevel):
         self.canvas.create_image(self.target_x, self.target_y, image=self.target)
 
         self.default_hex_color = normalized
-        self.default_rgb = [r, g, b]
-        self.rgb_color = [r, g, b]
+        rgb = [r, g, b]
+        self.rgb_color = rgb[:]
+        self.default_rgb = rgb[:]
         self.entry.delete(0, "end")
         self.entry.insert(0, normalized)
         self.entry.configure(fg_color=normalized)
@@ -372,8 +373,9 @@ class AskColor(customtkinter.CTkToplevel):
             self.canvas.create_image(self.target_x, self.target_y, image=self.target)
 
             self.default_hex_color = normalized
-            self.default_rgb = [r, g, b]
-            self.rgb_color = [r, g, b]
+            rgb = [r, g, b]
+            self.rgb_color = rgb[:]
+            self.default_rgb = rgb[:]
 
             self.entry.delete(0, "end")
             self.entry.insert(0, normalized)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -215,7 +215,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             self.brightness_slider_value.get(),
-            self.default_rgb,
+            self.default_rgb[:],
             self.slider,
             self.entry,
             command=self.command,
@@ -252,8 +252,9 @@ class CTkColorPicker(customtkinter.CTkFrame):
         self.canvas.create_image(self.target_x, self.target_y, image=self.target)
 
         self.default_hex_color = normalized
-        self.default_rgb = [r, g, b]
-        self.rgb_color = [r, g, b]
+        rgb = [r, g, b]
+        self.rgb_color = rgb[:]
+        self.default_rgb = rgb[:]
         self.entry.delete(0, "end")
         self.entry.insert(0, normalized)
         self.entry.configure(fg_color=normalized)
@@ -291,8 +292,9 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.canvas.create_image(self.target_x, self.target_y, image=self.target)
 
             self.default_hex_color = normalized
-            self.default_rgb = [r, g, b]
-            self.rgb_color = [r, g, b]
+            rgb = [r, g, b]
+            self.rgb_color = rgb[:]
+            self.default_rgb = rgb[:]
 
             self.entry.delete(0, "end")
             self.entry.insert(0, normalized)


### PR DESCRIPTION
## Summary
- keep rgb_color and default_rgb in sync when colors are set programmatically
- pass updated default_rgb to color_utils.update_colors for proper brightness handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c4ce1dd483218e06cd07f87418a6