### PR TITLE
Add color wheel conversion utilities

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -1,4 +1,5 @@
 import math
+import colorsys
 from typing import Sequence, Callable, List
 from PIL import Image
 import string
@@ -19,6 +20,51 @@ def normalize_hex(value: str | None) -> str | None:
     if len(value) == 6 and all(c in string.hexdigits for c in value):
         return "#" + value
     return None
+
+
+def rgb_to_hsv(r: int, g: int, b: int) -> tuple[float, float, float]:
+    """Return the HSV representation of an RGB color."""
+
+    return colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+
+
+def hsv_to_rgb(h: float, s: float, v: float) -> tuple[int, int, int]:
+    """Return the integer RGB representation of an HSV color."""
+
+    r, g, b = colorsys.hsv_to_rgb(h, s, v)
+    return int(round(r * 255)), int(round(g * 255)), int(round(b * 255))
+
+
+def hsv_to_wheel(h: float, s: float, image_dimension: int) -> tuple[float, float]:
+    """Convert HSV values to ``(x, y)`` wheel coordinates."""
+
+    radius = s * (image_dimension / 2 - 1)
+    angle = h * 2 * math.pi
+    x = image_dimension / 2 + radius * math.cos(angle)
+    y = image_dimension / 2 + radius * math.sin(angle)
+    return x, y
+
+
+def hex_to_wheel(hex_color: str | None, image_dimension: int) -> tuple[float, float, int]:
+    """Return wheel coordinates and brightness for ``hex_color``.
+
+    The color wheel image contains colors at full brightness. Colors that are
+    darker or lighter than those on the wheel are approximated by positioning
+    the target at their hue/saturation location with full brightness and
+    returning the original value component as the ``brightness`` slider value.
+    Achromatic colors (saturation ``0``) map to the center of the wheel.
+    """
+
+    normalized = normalize_hex(hex_color) if hex_color else None
+    center = image_dimension / 2
+    if normalized is None:
+        return center, center, 255
+
+    r, g, b = (int(normalized[i : i + 2], 16) for i in (1, 3, 5))
+    h, s, v = rgb_to_hsv(r, g, b)
+    brightness = int(round(v * 255))
+    target_x, target_y = hsv_to_wheel(h, s, image_dimension)
+    return target_x, target_y, brightness
 
 
 def projection_on_circle(

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -16,7 +16,7 @@ sys.modules['PIL.Image'] = Image_module
 # Add package directory to path without importing package __init__
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'CTkColorPicker'))
 
-from color_utils import update_colors, normalize_hex
+from color_utils import update_colors, normalize_hex, hex_to_wheel
 
 
 class DummyWidget:
@@ -102,3 +102,22 @@ def test_normalize_hex_invalid():
     assert normalize_hex('ggg') is None
     assert normalize_hex('') is None
     assert normalize_hex(None) is None
+
+
+def test_hex_to_wheel_red():
+    x, y, brightness = hex_to_wheel('#ff0000', 100)
+    assert round(x) == 99
+    assert round(y) == 50
+    assert brightness == 255
+
+
+def test_hex_to_wheel_gray():
+    x, y, brightness = hex_to_wheel('#808080', 100)
+    assert (round(x), round(y)) == (50, 50)
+    assert brightness == 128
+
+
+def test_hex_to_wheel_invalid():
+    x, y, brightness = hex_to_wheel('zzz', 100)
+    assert (round(x), round(y)) == (50, 50)
+    assert brightness == 255


### PR DESCRIPTION
## Summary
- add helpers for RGB↔HSV, HSV→wheel, and hex→wheel conversions
- document approximation for colors not represented on the wheel
- test hex-to-wheel mappings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c6d827808321a170e6a2c71fc6fd