### PR TITLE
Preserve last color on pixel lookup failure

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -78,14 +78,17 @@ def projection_on_circle(
 
 
 def get_target_color(
-    image: Image.Image, target_x: int, target_y: int, default_rgb: Sequence[int]
+    image: Image.Image, target_x: int, target_y: int, rgb_color: Sequence[int]
 ) -> List[int]:
-    """Return the RGB color of ``image`` at the given coordinates."""
+    """Return the RGB color of ``image`` at the given coordinates.
+
+    Falls back to ``rgb_color`` if the pixel cannot be retrieved.
+    """
     try:
         r, g, b = image.getpixel((target_x, target_y))[:3]
         return [r, g, b]
-    except AttributeError:
-        return list(default_rgb)
+    except Exception:
+        return list(rgb_color)
 
 
 def update_colors(
@@ -93,14 +96,17 @@ def update_colors(
     target_x: int,
     target_y: int,
     brightness: int,
-    default_rgb: Sequence[int],
+    rgb_color: Sequence[int],
     slider: any,
     widget: any,
     command: Callable[[str], None] | None = None,
     get_callback: Callable[[], str] | None = None,
 ) -> tuple[list[int], str]:
-    """Update color widgets and return the RGB list and hex color."""
-    rgb_color = get_target_color(image, target_x, target_y, default_rgb)
+    """Update color widgets and return the RGB list and hex color.
+
+    ``rgb_color`` provides the fallback when the target pixel cannot be read.
+    """
+    rgb_color = get_target_color(image, target_x, target_y, rgb_color)
     r = int(rgb_color[0] * (brightness / 255))
     g = int(rgb_color[1] * (brightness / 255))
     b = int(rgb_color[2] * (brightness / 255))

--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -296,7 +296,7 @@ class AskColor(customtkinter.CTkToplevel):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             self.brightness_slider_value.get(),
-            self.default_rgb[:],
+            self.rgb_color[:],
             self.slider,
             self.entry,
         )

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -215,7 +215,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             self.brightness_slider_value.get(),
-            self.default_rgb[:],
+            self.rgb_color[:],
             self.slider,
             self.entry,
             command=self.command,

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -50,6 +50,11 @@ class DummyImage:
         return self.color
 
 
+class FailingImage:
+    def getpixel(self, coords):
+        raise ValueError("fail")
+
+
 def test_update_colors_returns_hex_and_rgb():
     img = DummyImage((255, 0, 0))
     slider, label = DummyWidget(), DummyWidget()
@@ -88,6 +93,15 @@ def test_update_colors_entry_widget():
     assert entry.text == '#00ff00'
     assert entry._fg_color == '#00ff00'
     assert entry.config['text_color'] == 'black'
+
+
+def test_update_colors_uses_fallback_on_failure():
+    img = FailingImage()
+    slider, label = DummyWidget(), DummyWidget()
+    last_color = [1, 2, 3]
+    rgb, hex_color = update_colors(img, 0, 0, 255, last_color, slider, label)
+    assert rgb == last_color
+    assert hex_color == '#010203'
 
 
 def test_normalize_hex_valid():


### PR DESCRIPTION
## Summary
- return the previous color when sampling the wheel fails instead of a default
- allow `update_colors` to accept the current color as its fallback
- adjust color picker widgets and tests to pass the last known color
- add regression test for the fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c967bd908321bf6badd3db4ef867