### PR TITLE
Fix incorrect color wheel reticle placement from hex input

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -41,7 +41,7 @@ def hsv_to_wheel(h: float, s: float, image_dimension: int) -> tuple[float, float
     radius = s * (image_dimension / 2 - 1)
     angle = h * 2 * math.pi
     x = image_dimension / 2 + radius * math.cos(angle)
-    y = image_dimension / 2 + radius * math.sin(angle)
+    y = image_dimension / 2 - radius * math.sin(angle)
     return x, y
 
 

--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -322,7 +322,7 @@ class AskColor(customtkinter.CTkToplevel):
         angle = h * 2 * math.pi
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
-        self.target_y = self.image_dimension / 2 + radius * math.sin(angle)
+        self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
 
         self.canvas.delete("all")
         self.canvas.create_image(
@@ -364,7 +364,7 @@ class AskColor(customtkinter.CTkToplevel):
             angle = h * 2 * math.pi
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
-            self.target_y = self.image_dimension / 2 + radius * math.sin(angle)
+            self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
 
             self.canvas.delete("all")
             self.canvas.create_image(

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -243,7 +243,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         angle = h * 2 * math.pi
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
-        self.target_y = self.image_dimension / 2 + radius * math.sin(angle)
+        self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
 
         self.canvas.delete("all")
         self.canvas.create_image(
@@ -283,7 +283,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             angle = h * 2 * math.pi
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
-            self.target_y = self.image_dimension / 2 + radius * math.sin(angle)
+            self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
 
             self.canvas.delete("all")
             self.canvas.create_image(


### PR DESCRIPTION
## Summary
- Correct wheel coordinate conversion to account for screen Y-axis
- Update widget and dialog to use corrected Y coordinate when placing the color target

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d02ddcec832190bc80f5f24af982