### PR TITLE
Offset hue angle for consistent color wheel alignment

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -5,6 +5,13 @@ from PIL import Image
 import string
 
 
+TAU = 2 * math.pi
+"""Full circle constant ``2π`` used for angle calculations."""
+
+HUE_OFFSET = math.pi / 3
+"""Hue offset applied to align wheel coordinates with hex colors."""
+
+
 def normalize_hex(value: str | None) -> str | None:
     """Return a normalized ``#rrggbb`` color string or ``None`` if invalid."""
 
@@ -39,7 +46,7 @@ def hsv_to_wheel(h: float, s: float, image_dimension: int) -> tuple[float, float
     """Convert HSV values to ``(x, y)`` wheel coordinates."""
 
     radius = s * (image_dimension / 2 - 1)
-    angle = h * 2 * math.pi
+    angle = (h * TAU + HUE_OFFSET) % TAU
     x = image_dimension / 2 + radius * math.cos(angle)
     y = image_dimension / 2 - radius * math.sin(angle)
     return x, y

--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -14,6 +14,8 @@ from .color_utils import (
     projection_on_circle,
     update_colors as utils_update_colors,
     normalize_hex,
+    TAU,
+    HUE_OFFSET,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -319,7 +321,7 @@ class AskColor(customtkinter.CTkToplevel):
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
         self.brightness_slider_value.set(int(v * 255))
 
-        angle = h * 2 * math.pi
+        angle = (h * TAU + HUE_OFFSET) % TAU
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
         self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
@@ -361,7 +363,7 @@ class AskColor(customtkinter.CTkToplevel):
 
             self.brightness_slider_value.set(int(v * 255))
 
-            angle = h * 2 * math.pi
+            angle = (h * TAU + HUE_OFFSET) % TAU
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
             self.target_y = self.image_dimension / 2 - radius * math.sin(angle)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -13,6 +13,8 @@ from .color_utils import (
     projection_on_circle,
     update_colors as utils_update_colors,
     normalize_hex,
+    TAU,
+    HUE_OFFSET,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -268,7 +270,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
         self.brightness_slider_value.set(int(v * 255))
 
-        angle = h * 2 * math.pi
+        angle = (h * TAU + HUE_OFFSET) % TAU
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
         self.target_y = self.image_dimension / 2 - radius * math.sin(angle)
@@ -320,7 +322,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
 
             self.brightness_slider_value.set(int(v * 255))
 
-            angle = h * 2 * math.pi
+            angle = (h * TAU + HUE_OFFSET) % TAU
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
             self.target_y = self.image_dimension / 2 - radius * math.sin(angle)

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -120,8 +120,8 @@ def test_normalize_hex_invalid():
 
 def test_hex_to_wheel_red():
     x, y, brightness = hex_to_wheel('#ff0000', 100)
-    assert round(x) == 99
-    assert round(y) == 50
+    assert round(x) == 74
+    assert round(y) == 8
     assert brightness == 255
 
 


### PR DESCRIPTION
## Summary
- shift hue calculations by 60° across widget, dialog and utilities
- centralize 2π and hue-offset constants for reuse
- update tests for new wheel coordinates

## Testing
- `pytest -q`
- attempted to instantiate CTkColorPicker widget for `_debug_auto_position` verification, but Tk initialization failed due to missing display (`_tkinter.TclError`)


------
https://chatgpt.com/codex/tasks/task_e_68980e1fc0fc8321ae8cb5eb1ef5e80f