### PR TITLE
Remove wheel conversion utilities

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -41,39 +41,6 @@ def hsv_to_rgb(h: float, s: float, v: float) -> tuple[int, int, int]:
     r, g, b = colorsys.hsv_to_rgb(h, s, v)
     return int(round(r * 255)), int(round(g * 255)), int(round(b * 255))
 
-
-def hsv_to_wheel(h: float, s: float, image_dimension: int) -> tuple[float, float]:
-    """Convert HSV values to ``(x, y)`` wheel coordinates."""
-
-    radius = s * (image_dimension / 2 - 1)
-    angle = (h * TAU + HUE_OFFSET) % TAU
-    x = image_dimension / 2 + radius * math.cos(angle)
-    y = image_dimension / 2 - radius * math.sin(angle)
-    return x, y
-
-
-def hex_to_wheel(hex_color: str | None, image_dimension: int) -> tuple[float, float, int]:
-    """Return wheel coordinates and brightness for ``hex_color``.
-
-    The color wheel image contains colors at full brightness. Colors that are
-    darker or lighter than those on the wheel are approximated by positioning
-    the target at their hue/saturation location with full brightness and
-    returning the original value component as the ``brightness`` slider value.
-    Achromatic colors (saturation ``0``) map to the center of the wheel.
-    """
-
-    normalized = normalize_hex(hex_color) if hex_color else None
-    center = image_dimension / 2
-    if normalized is None:
-        return center, center, 255
-
-    r, g, b = (int(normalized[i : i + 2], 16) for i in (1, 3, 5))
-    h, s, v = rgb_to_hsv(r, g, b)
-    brightness = int(round(v * 255))
-    target_x, target_y = hsv_to_wheel(h, s, image_dimension)
-    return target_x, target_y, brightness
-
-
 def projection_on_circle(
     point_x: float, point_y: float, circle_x: float, circle_y: float, radius: float
 ) -> tuple[float, float]:

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -16,7 +16,7 @@ sys.modules['PIL.Image'] = Image_module
 # Add package directory to path without importing package __init__
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'CTkColorPicker'))
 
-from color_utils import update_colors, normalize_hex, hex_to_wheel
+from color_utils import update_colors, normalize_hex
 
 
 class DummyWidget:
@@ -116,22 +116,3 @@ def test_normalize_hex_invalid():
     assert normalize_hex('ggg') is None
     assert normalize_hex('') is None
     assert normalize_hex(None) is None
-
-
-def test_hex_to_wheel_red():
-    x, y, brightness = hex_to_wheel('#ff0000', 100)
-    assert round(x) == 92
-    assert round(y) == 26
-    assert brightness == 255
-
-
-def test_hex_to_wheel_gray():
-    x, y, brightness = hex_to_wheel('#808080', 100)
-    assert (round(x), round(y)) == (50, 50)
-    assert brightness == 128
-
-
-def test_hex_to_wheel_invalid():
-    x, y, brightness = hex_to_wheel('zzz', 100)
-    assert (round(x), round(y)) == (50, 50)
-    assert brightness == 255


### PR DESCRIPTION
## Summary
- drop unused `hsv_to_wheel` and `hex_to_wheel` helpers
- adjust tests to stop referencing removed functions

## Testing
- `pytest -q`
- `rg "hsv_to_wheel" -n || true`
- `rg "hex_to_wheel" -n || true`


------
https://chatgpt.com/codex/tasks/task_e_68997f3b388c8321a7114aeea2c7d329