### PR TITLE
Remove stray debug import comment

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -21,7 +21,6 @@ from .color_utils import (
 
 PATH = os.path.dirname(os.path.realpath(__file__))
 
-
 class AskColor(customtkinter.CTkToplevel):
     """Toplevel dialog for selecting a color via a wheel and slider."""
 

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -107,7 +107,6 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.wheel = ImageTk.PhotoImage(self.img1)
 
         # Build hue angle map
-        # from .color_utils import build_hue_to_angle_lookup, hue_to_angle
         self._hue_lookup = build_hue_to_angle_lookup(self.img1)
         
         with Image.open(os.path.join(PATH, "target.png")) as img:


### PR DESCRIPTION
## Summary
- drop leftover debug import comment from the widget module
- tidy whitespace around module-level constant in color picker implementation

## Testing
- `python -m py_compile CTkColorPicker/ctk_color_picker.py CTkColorPicker/ctk_color_picker_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_689982f1aa90832191f45a2baed144f0