### PR TITLE
Fix brightness slider max value

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -161,7 +161,7 @@ class AskColor(customtkinter.CTkToplevel):
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel
         )
         self.brightness_slider_value = customtkinter.IntVar()
-        self.brightness_slider_value.set(255)
+        self.brightness_slider_value.set(256)
 
         self.slider = customtkinter.CTkSlider(
             master=self.frame,
@@ -170,7 +170,7 @@ class AskColor(customtkinter.CTkToplevel):
             button_length=15,
             progress_color=self.default_hex_color,
             from_=0,
-            to=255,
+            to=256,
             variable=self.brightness_slider_value,
             number_of_steps=256,
             button_corner_radius=self.corner_radius,
@@ -297,11 +297,12 @@ class AskColor(customtkinter.CTkToplevel):
     def update_colors(self) -> None:
         """Update widget colors based on the current selection and brightness."""
 
+        brightness = min(self.brightness_slider_value.get(), 255)
         self.rgb_color, self.default_hex_color = utils_update_colors(
             self.img1,
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
-            self.brightness_slider_value.get(),
+            brightness,
             self.rgb_color[:],
             self.slider,
             self.entry,
@@ -317,13 +318,14 @@ class AskColor(customtkinter.CTkToplevel):
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)
             self.slider.configure(progress_color=self.default_hex_color)
-            self.brightness_slider_value.set(255)
+            self.brightness_slider_value.set(256)
             self.entry.focus()
             return
 
         r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
-        self.brightness_slider_value.set(int(v * 255))
+        value = int(v * 255)
+        self.brightness_slider_value.set(value if value < 255 else 256)
 
         try:
             angle = hue_to_angle(h, self._hue_lookup)
@@ -369,7 +371,8 @@ class AskColor(customtkinter.CTkToplevel):
             r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
             h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
 
-            self.brightness_slider_value.set(int(v * 255))
+            value = int(v * 255)
+            self.brightness_slider_value.set(value if value < 255 else 256)
 
             try:
                 angle = hue_to_angle(h, self._hue_lookup)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -120,7 +120,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel
         )
         self.brightness_slider_value = customtkinter.IntVar()
-        self.brightness_slider_value.set(255)
+        self.brightness_slider_value.set(256)
 
         self.slider = customtkinter.CTkSlider(
             master=self.wheel_frame,
@@ -129,7 +129,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             button_length=15,
             progress_color=self.default_hex_color,
             from_=0,
-            to=255,
+            to=256,
             variable=self.brightness_slider_value,
             number_of_steps=256,
             button_corner_radius=self.corner_radius,
@@ -218,11 +218,12 @@ class CTkColorPicker(customtkinter.CTkFrame):
     def update_colors(self) -> None:
         """Update widget colors and invoke the callback if provided."""
 
+        brightness = min(self.brightness_slider_value.get(), 255)
         self.rgb_color, self.default_hex_color = utils_update_colors(
             self.img1,
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
-            self.brightness_slider_value.get(),
+            brightness,
             self.rgb_color[:],
             self.slider,
             self.entry,
@@ -240,13 +241,14 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)
             self.slider.configure(progress_color=self.default_hex_color)
-            self.brightness_slider_value.set(255)
+            self.brightness_slider_value.set(256)
             self.entry.focus()
             return
 
         r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
-        self.brightness_slider_value.set(int(v * 255))
+        value = int(v * 255)
+        self.brightness_slider_value.set(value if value < 255 else 256)
 
         try:
             angle = hue_to_angle(h, self._hue_lookup)
@@ -290,7 +292,8 @@ class CTkColorPicker(customtkinter.CTkFrame):
             r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
             h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
 
-            self.brightness_slider_value.set(int(v * 255))
+            value = int(v * 255)
+            self.brightness_slider_value.set(value if value < 255 else 256)
 
             try:
                 angle = hue_to_angle(h, self._hue_lookup)


### PR DESCRIPTION
## Summary
- allow brightness slider to reach full intensity by extending range and clamping value
- adjust hex input handling to respect updated slider range

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a4a6c90988321b4dfed52dd2c840d