### PR TITLE
Derive color wheel values from HSV math

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -303,7 +303,6 @@ class AskColor(customtkinter.CTkToplevel):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             brightness,
-            self.rgb_color[:],
             self.slider,
             self.entry,
         )

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -224,7 +224,6 @@ class CTkColorPicker(customtkinter.CTkFrame):
             getattr(self, "target_x", 0),
             getattr(self, "target_y", 0),
             brightness,
-            self.rgb_color[:],
             self.slider,
             self.entry,
             command=self.command,


### PR DESCRIPTION
## Summary
- Compute hue and saturation from target coordinates and convert via `colorsys.hsv_to_rgb`
- Pass coordinates and brightness directly from picker widgets
- Drop unused image sampling helper

## Testing
- `pytest -q`
- Manual HSV wheel check ensuring red/green/blue map to #ff0000/#00ff00/#0000ff

------
https://chatgpt.com/codex/tasks/task_e_689a55116d988321a41fb6eb77ad16a2