### PR TITLE
Simplify brightness slider to 0–255 range

### DIFF
--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -161,7 +161,7 @@ class AskColor(customtkinter.CTkToplevel):
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel
         )
         self.brightness_slider_value = customtkinter.IntVar()
-        self.brightness_slider_value.set(256)
+        self.brightness_slider_value.set(255)
 
         self.slider = customtkinter.CTkSlider(
             master=self.frame,
@@ -170,9 +170,9 @@ class AskColor(customtkinter.CTkToplevel):
             button_length=15,
             progress_color=self.default_hex_color,
             from_=0,
-            to=256,
+            to=255,
             variable=self.brightness_slider_value,
-            number_of_steps=256,
+            number_of_steps=255,
             button_corner_radius=self.corner_radius,
             corner_radius=self.corner_radius,
             button_color=self.button_color,
@@ -297,7 +297,7 @@ class AskColor(customtkinter.CTkToplevel):
     def update_colors(self) -> None:
         """Update widget colors based on the current selection and brightness."""
 
-        brightness = min(self.brightness_slider_value.get(), 255)
+        brightness = self.brightness_slider_value.get()
         self.rgb_color, self.default_hex_color = utils_update_colors(
             self.img1,
             getattr(self, "target_x", 0),
@@ -317,14 +317,14 @@ class AskColor(customtkinter.CTkToplevel):
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)
             self.slider.configure(progress_color=self.default_hex_color)
-            self.brightness_slider_value.set(256)
+            self.brightness_slider_value.set(255)
             self.entry.focus()
             return
 
         r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
         value = int(v * 255)
-        self.brightness_slider_value.set(value if value < 255 else 256)
+        self.brightness_slider_value.set(value)
 
         try:
             angle = hue_to_angle(h, self._hue_lookup)
@@ -371,7 +371,7 @@ class AskColor(customtkinter.CTkToplevel):
             h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
 
             value = int(v * 255)
-            self.brightness_slider_value.set(value if value < 255 else 256)
+            self.brightness_slider_value.set(value)
 
             try:
                 angle = hue_to_angle(h, self._hue_lookup)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -120,7 +120,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.image_dimension / 2, self.image_dimension / 2, image=self.wheel
         )
         self.brightness_slider_value = customtkinter.IntVar()
-        self.brightness_slider_value.set(256)
+        self.brightness_slider_value.set(255)
 
         self.slider = customtkinter.CTkSlider(
             master=self.wheel_frame,
@@ -129,9 +129,9 @@ class CTkColorPicker(customtkinter.CTkFrame):
             button_length=15,
             progress_color=self.default_hex_color,
             from_=0,
-            to=256,
+            to=255,
             variable=self.brightness_slider_value,
-            number_of_steps=256,
+            number_of_steps=255,
             button_corner_radius=self.corner_radius,
             corner_radius=self.corner_radius,
             command=lambda x: self.update_colors(),
@@ -218,7 +218,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
     def update_colors(self) -> None:
         """Update widget colors and invoke the callback if provided."""
 
-        brightness = min(self.brightness_slider_value.get(), 255)
+        brightness = self.brightness_slider_value.get()
         self.rgb_color, self.default_hex_color = utils_update_colors(
             self.img1,
             getattr(self, "target_x", 0),
@@ -240,14 +240,14 @@ class CTkColorPicker(customtkinter.CTkFrame):
             self.entry.insert(0, self.default_hex_color)
             self.entry.configure(fg_color=self.default_hex_color)
             self.slider.configure(progress_color=self.default_hex_color)
-            self.brightness_slider_value.set(256)
+            self.brightness_slider_value.set(255)
             self.entry.focus()
             return
 
         r, g, b = tuple(int(normalized[i : i + 2], 16) for i in (1, 3, 5))
         h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
         value = int(v * 255)
-        self.brightness_slider_value.set(value if value < 255 else 256)
+        self.brightness_slider_value.set(value)
 
         try:
             angle = hue_to_angle(h, self._hue_lookup)
@@ -292,7 +292,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
 
             value = int(v * 255)
-            self.brightness_slider_value.set(value if value < 255 else 256)
+            self.brightness_slider_value.set(value)
 
             try:
                 angle = hue_to_angle(h, self._hue_lookup)


### PR DESCRIPTION
## Summary
- Configure brightness sliders for an exact 0–255 range with 255 steps
- Remove slider clamping and sentinel value logic in color update methods
- Set hex input and initial color to drive sliders directly within 0–255

## Testing
- `python -m py_compile CTkColorPicker/ctk_color_picker.py CTkColorPicker/ctk_color_picker_widget.py`
- `python - <<'PY'
import tkinter, customtkinter
root = tkinter.Tcl()
var = customtkinter.IntVar(master=root)
for v in (0, 128, 255):
    var.set(v)
    print(v, var.get())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689a57dbb1448321a6e55d054f1a82ad