### PR TITLE
Remove Hue offset constant from color picker

### DIFF
--- a/CTkColorPicker/color_utils.py
+++ b/CTkColorPicker/color_utils.py
@@ -8,8 +8,8 @@ import bisect
 TAU = 2 * math.pi
 """Full circle constant ``2π`` used for angle calculations."""
 
-HUE_OFFSET = math.pi / 6
-"""Hue offset applied to align wheel coordinates with hex colors."""
+HUE_OFFSET = 0
+"""Legacy hue offset (no longer applied)."""
 
 
 def normalize_hex(value: str | None) -> str | None:
@@ -75,7 +75,7 @@ def update_colors(
     dy = cy - target_y  # invert y-axis for cartesian coordinates
 
     angle = math.atan2(dy, dx)
-    h_val = ((angle - HUE_OFFSET) % TAU) / TAU
+    h_val = (angle % TAU) / TAU
 
     radius = math.sqrt(dx * dx + dy * dy)
     max_radius = min(cx, cy) - 1

--- a/CTkColorPicker/ctk_color_picker.py
+++ b/CTkColorPicker/ctk_color_picker.py
@@ -16,7 +16,6 @@ from .color_utils import (
     build_hue_to_angle_lookup,
     hue_to_angle,
     TAU,
-    HUE_OFFSET,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -329,7 +328,7 @@ class AskColor(customtkinter.CTkToplevel):
         try:
             angle = hue_to_angle(h, self._hue_lookup)
         except Exception:
-            angle = (h * TAU + HUE_OFFSET) % TAU  # safety fallback
+            angle = (h * TAU) % TAU  # safety fallback
 
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
@@ -376,7 +375,7 @@ class AskColor(customtkinter.CTkToplevel):
             try:
                 angle = hue_to_angle(h, self._hue_lookup)
             except Exception:
-                angle = (h * TAU + HUE_OFFSET) % TAU  # safety fallback
+                angle = (h * TAU) % TAU  # safety fallback
 
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)

--- a/CTkColorPicker/ctk_color_picker_widget.py
+++ b/CTkColorPicker/ctk_color_picker_widget.py
@@ -16,7 +16,6 @@ from .color_utils import (
     build_hue_to_angle_lookup,
     hue_to_angle,
     TAU,
-    HUE_OFFSET,
 )
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -252,7 +251,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
         try:
             angle = hue_to_angle(h, self._hue_lookup)
         except Exception:
-            angle = (h * TAU + HUE_OFFSET) % TAU  # safety fallback
+            angle = (h * TAU) % TAU  # safety fallback
 
         radius = s * (self.image_dimension / 2 - 1)
         self.target_x = self.image_dimension / 2 + radius * math.cos(angle)
@@ -297,7 +296,7 @@ class CTkColorPicker(customtkinter.CTkFrame):
             try:
                 angle = hue_to_angle(h, self._hue_lookup)
             except Exception:
-                angle = (h * TAU + HUE_OFFSET) % TAU  # safety fallback
+                angle = (h * TAU) % TAU  # safety fallback
 
             radius = s * (self.image_dimension / 2 - 1)
             self.target_x = self.image_dimension / 2 + radius * math.cos(angle)


### PR DESCRIPTION
## Summary
- eliminate `HUE_OFFSET` constant and use raw angles for hue
- drop `HUE_OFFSET` imports and adjust fallback conversions
- verify color conversions keep hex codes at max brightness

## Testing
- `pytest -q`
- `python manual_hex_verify.py` *(inline script verifying several sample hex codes)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cebdc7c8321923146405e869742